### PR TITLE
Fix profile picture blur on current WhatsApp Web

### DIFF
--- a/src/css/noDelay.css
+++ b/src/css/noDelay.css
@@ -122,11 +122,12 @@ div.xkhd6sd._ajxt > ._ajxu > div:hover /* business phone number in details info 
 div._ak1d > div:first-child > div:first-child > :not(:first-child):hover /* user/group name in starred message list */,
 
 /* profilePic */
-div.x78zum5>div.x6s0dn4.x78zum5.x1c4vz4f.x2lah0s.x1y332i5.x18d9i69.xexx8yu.x1cbfl22.xbmws1g > div:hover /* user/group profile pic in message list */,
+div[role="gridcell"] .xbmws1g > div:hover /* user/group profile pic in message list */,
+div[role="listitem"] .xbmws1g > div:hover /* user/group profile pic in archived message list */,
 div[role="listitem"] ._ak8h:not(:has([data-icon="community-group"])):hover /* user/group profile pic in archived message list */,
 div.x6s0dn4.x78zum5.x1c4vz4f.x2lah0s.x18d9i69.xexx8yu.x1pic42t.xe2zdcy > div:hover /* user/group profile pic in details list and popup list */,
 div[role="dialog"] ._ak8h:hover /* user/group profile pic in popup list */,
-header div[role="button"]:first-child div.x1n2onr6.x1c9tyrk.xeusxvb.x1pahc9y.x1ertn4p:hover /* user/group profile pic at the top of chat panel */,
+header div[role="button"]:first-child img:hover /* user/group profile pic at the top of chat panel */,
 header .html-span div.x1n2onr6.x1f2iure.x1fgtraw.xgd8bvy:hover /* community profile pic in community subgroup switcher */,
 div.x16ye13r.x10l6tqk.x1wnpwf8.x1vjfegm div[role="button"]:hover /* user profile pic in group chat messages */,
 div.x1okw0bk.x1yh7se0 div.x1n2onr6.x1c9tyrk.xeusxvb.x1pahc9y.x1ertn4p:hover /* user profile pic in contact attachment */,

--- a/src/css/profilePic.css
+++ b/src/css/profilePic.css
@@ -14,10 +14,11 @@
 .b021xdil /* multi contacts attachment */,
 
 /* updated wa version (v2.3000.xx) */
-div.x78zum5>div.x6s0dn4.x78zum5.x1c4vz4f.x2lah0s.x1y332i5.x18d9i69.xexx8yu.x1cbfl22.xbmws1g > div /* user/group profile pic in message list and archived message list*/,
+div[role="gridcell"] .xbmws1g > div /* user/group profile pic in message list */,
+div[role="listitem"] .xbmws1g > div /* user/group profile pic in archived message list */,
 div.x6s0dn4.x78zum5.x1c4vz4f.x2lah0s.x18d9i69.xexx8yu.x1pic42t.xe2zdcy > div /* user/group profile pic in details list and popup list */,
 div[role="dialog"] ._ak8h /* user/group profile pic in popup list */,
-header div[role="button"]:first-child div.x1n2onr6.x1c9tyrk.xeusxvb.x1pahc9y.x1ertn4p /* user/group profile pic at the top of chat panel */,
+header div[role="button"]:first-child img /* user/group profile pic at the top of chat panel */,
 header .html-span div.x1n2onr6.x1f2iure.x1fgtraw.xgd8bvy /* community profile pic in community subgroup switcher */,
 div.x16ye13r.x10l6tqk.x1wnpwf8.x1vjfegm div[role="button"] /* user profile pic in group chat messages */,
 div.x1okw0bk.x1yh7se0 div.x1n2onr6.x1c9tyrk.xeusxvb.x1pahc9y.x1ertn4p /* user profile pic in contact attachment */,
@@ -70,11 +71,12 @@ div.x1okw0bk.xbelrpt > div.x1n2onr6.x1c9tyrk.xeusxvb.x1pahc9y.x1ertn4p /* user p
 .njub1g37 .kk3akd72.claouzo6:hover /*Starred message profile pic*/,
 
 /* updated wa version (v2.3000.xx) */
-div.x78zum5>div.x6s0dn4.x78zum5.x1c4vz4f.x2lah0s.x1y332i5.x18d9i69.xexx8yu.x1cbfl22.xbmws1g > div:hover /* user/group profile pic in message list */,
+div[role="gridcell"] .xbmws1g > div:hover /* user/group profile pic in message list */,
+div[role="listitem"] .xbmws1g > div:hover /* user/group profile pic in archived message list */,
 div[role="listitem"] ._ak8h:not(:has([data-icon="community-group"])):hover /* user/group profile pic in archived message list */,
 div.x6s0dn4.x78zum5.x1c4vz4f.x2lah0s.x18d9i69.xexx8yu.x1pic42t.xe2zdcy > div:hover /* user/group profile pic in details list and popup list */,
 div[role="dialog"] ._ak8h:hover /* user/group profile pic in popup list */,
-header div[role="button"]:first-child div.x1n2onr6.x1c9tyrk.xeusxvb.x1pahc9y.x1ertn4p:hover /* user/group profile pic at the top of chat panel */,
+header div[role="button"]:first-child img:hover /* user/group profile pic at the top of chat panel */,
 header .html-span div.x1n2onr6.x1f2iure.x1fgtraw.xgd8bvy:hover /* community profile pic in community subgroup switcher */,
 div.x16ye13r.x10l6tqk.x1wnpwf8.x1vjfegm div[role="button"]:hover /* user profile pic in group chat messages */,
 div.x1okw0bk.x1yh7se0 div.x1n2onr6.x1c9tyrk.xeusxvb.x1pahc9y.x1ertn4p:hover /* user profile pic in contact attachment */,

--- a/src/css/unblurActive.css
+++ b/src/css/unblurActive.css
@@ -120,11 +120,12 @@ body:hover div.xkhd6sd._ajxt > ._ajxu > div /* business phone number in details 
 body:hover div._ak1d > div:first-child > div:first-child > :not(:first-child) /* user/group name in starred message list */,
 
 /* profilePic */
-body:hover div.x78zum5>div.x6s0dn4.x78zum5.x1c4vz4f.x2lah0s.x1y332i5.x18d9i69.xexx8yu.x1cbfl22.xbmws1g > div /* user/group profile pic in message list */,
+body:hover div[role="gridcell"] .xbmws1g > div /* user/group profile pic in message list */,
+body:hover div[role="listitem"] .xbmws1g > div /* user/group profile pic in archived message list */,
 body:hover div[role="listitem"] ._ak8h:not(:has([data-icon="community-group"])) /* user/group profile pic in archived message list */,
 body:hover div.x6s0dn4.x78zum5.x1c4vz4f.x2lah0s.x18d9i69.xexx8yu.x1pic42t.xe2zdcy > div /* user/group profile pic in details list and popup list */,
 body:hover div[role="dialog"] ._ak8h /* user/group profile pic in popup list */,
-body:hover header div[role="button"]:first-child div.x1n2onr6.x1c9tyrk.xeusxvb.x1pahc9y.x1ertn4p /* user/group profile pic at the top of chat panel */,
+body:hover header div[role="button"]:first-child img /* user/group profile pic at the top of chat panel */,
 body:hover header .html-span div.x1n2onr6.x1f2iure.x1fgtraw.xgd8bvy /* community profile pic in community subgroup switcher */,
 body:hover div.x16ye13r.x10l6tqk.x1wnpwf8.x1vjfegm div[role="button"] /* user profile pic in group chat messages */,
 body:hover div.x1okw0bk.x1yh7se0 div.x1n2onr6.x1c9tyrk.xeusxvb.x1pahc9y.x1ertn4p /* user profile pic in contact attachment */,


### PR DESCRIPTION
## Summary
- replace the stale generated chat-list selector with the current .xbmws1g wrapper
- cover both normal and archived chat rows
- keep the chat header, hover, no-delay, and unblur-all selectors in sync

## Tested
- Chrome 150 on the current WhatsApp Web
- normal chat list with no chat open
- open chat and archived chat list
- hover reveal and blur restoration

Fixes #8
Fixes #10