### PR TITLE
Add a daily privacy schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Table of Contents (Click to Show/Hide)
 
 - [Customize it](#customize-it)
   - [Quick Toggle](#quick-toggle)
+  - [Privacy Schedule](#privacy-schedule)
 - [Installation](#installation)
   - [Chrome](#chrome)
   - [Microsoft Edge](#microsoft-edge)
@@ -55,6 +56,7 @@ It adapts to your needs by letting you decide which elements you want to blur. Y
 - No transition delay: _Allows you to turn off the delay before revealing an item on hover._
 - Unblur all on app hover: _Unblurs all elements when you hover over the WhatsApp Web app._
 - Blur WhatsApp on Idle: _Blurs WhatsApp when there is no mouse/keyboard activity after a certain time._
+- Privacy schedule: _Automatically enables and disables privacy at chosen times each day._
 - Advanced Settings: _Customize the blur amount (in pixels) for various elements independently and set the idle timeout duration._
 - Theme Toggle: _Switch between Light, Dark, or System Preference theme for the extension._
 
@@ -65,6 +67,10 @@ To change this navigate to:
 
 - Chrome: [chrome://extensions/shortcuts](chrome://extensions/shortcuts)
 - Firefox: [about:addons](about:addons) -> Settings icon on the top right -> Manage Extension Shortcuts
+
+### Privacy Schedule
+
+The privacy schedule is optional and disabled by default. It uses your browser's local time and supports schedules that cross midnight. You can still toggle privacy manually while it is enabled; the manual choice remains in place until the next scheduled start or end time.
 
 ## Installation
 

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -17,6 +17,24 @@
     "extensionSettings": {
         "message": "Einstellungen"
     },
+    "privacySchedule": {
+        "message": "Datenschutz-Zeitplan"
+    },
+    "privacyScheduleDescription": {
+        "message": "Datenschutz automatisch zu festgelegten Zeiten ein- und ausschalten."
+    },
+    "scheduleStart": {
+        "message": "Start"
+    },
+    "scheduleEnd": {
+        "message": "Ende"
+    },
+    "scheduleHelp": {
+        "message": "Verwendet die lokale Browserzeit. Manuelle Änderungen gelten bis zum nächsten geplanten Zeitpunkt."
+    },
+    "scheduleInvalid": {
+        "message": "Start- und Endzeit müssen unterschiedlich sein."
+    },
     "toggleMessages": {
         "message": "Alle Nachrichten im Chat"
     },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -17,6 +17,24 @@
     "extensionSettings": {
         "message": "Settings"
     },
+    "privacySchedule": {
+        "message": "Privacy schedule"
+    },
+    "privacyScheduleDescription": {
+        "message": "Automatically turn privacy on and off at set times."
+    },
+    "scheduleStart": {
+        "message": "Start"
+    },
+    "scheduleEnd": {
+        "message": "End"
+    },
+    "scheduleHelp": {
+        "message": "Uses your browser's local time. Manual changes last until the next scheduled time."
+    },
+    "scheduleInvalid": {
+        "message": "Start and end times must be different."
+    },
     "toggleMessages": {
         "message": "All messages in chat"
     },

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -17,6 +17,24 @@
     "extensionSettings": {
         "message": "Configurações"
     },
+    "privacySchedule": {
+        "message": "Agendamento de privacidade"
+    },
+    "privacyScheduleDescription": {
+        "message": "Ative e desative a privacidade automaticamente nos horários definidos."
+    },
+    "scheduleStart": {
+        "message": "Início"
+    },
+    "scheduleEnd": {
+        "message": "Fim"
+    },
+    "scheduleHelp": {
+        "message": "Usa o horário local do navegador. Alterações manuais valem até o próximo horário agendado."
+    },
+    "scheduleInvalid": {
+        "message": "Os horários de início e fim precisam ser diferentes."
+    },
     "toggleMessages": {
         "message": "Todas as mensagens no chat"
     },

--- a/src/background.js
+++ b/src/background.js
@@ -9,7 +9,13 @@ if (typeof browser == "undefined") {
   globalThis.browser = chrome;
 }
 
+if (typeof globalThis.privacySchedule === "undefined" && typeof importScripts === "function") {
+  importScripts("schedule.js");
+}
+
 const settingsIdentifier = "settings";
+const scheduleIdentifier = "privacySchedule";
+const scheduleAlarmName = "privacy-schedule";
 const defaultSettings = {
   settings: {
     on: true,
@@ -44,7 +50,47 @@ const defaultSettings = {
 };
 const requiredPermissions = { 
   origins: ["https://web.whatsapp.com/*"],
-  permissions: ["storage"]
+  permissions: ["storage", "alarms"]
+}
+
+async function ensurePrivacySchedule() {
+  const result = await browser.storage.sync.get([scheduleIdentifier]);
+  if (result.hasOwnProperty(scheduleIdentifier)
+    && globalThis.privacySchedule.isValid(result[scheduleIdentifier])) {
+    return result[scheduleIdentifier];
+  }
+
+  const schedule = { ...globalThis.privacySchedule.defaults };
+  await browser.storage.sync.set({ [scheduleIdentifier]: schedule });
+  return schedule;
+}
+
+async function updatePrivacySchedule(applyState) {
+  const result = await browser.storage.sync.get([settingsIdentifier, scheduleIdentifier]);
+  const schedule = result[scheduleIdentifier];
+
+  await browser.alarms.clear(scheduleAlarmName);
+  if (!schedule?.enabled || !globalThis.privacySchedule.isValid(schedule)) return;
+
+  if (applyState && result.hasOwnProperty(settingsIdentifier)) {
+    const on = globalThis.privacySchedule.isActive(schedule);
+    if (result.settings.on !== on) {
+      result.settings.on = on;
+      await browser.storage.sync.set({ [settingsIdentifier]: result.settings });
+    }
+  }
+
+  await browser.alarms.create(scheduleAlarmName, {
+    when: globalThis.privacySchedule.getNextChange(schedule)
+  });
+}
+
+async function ensurePrivacyScheduleAlarm() {
+  const schedule = await ensurePrivacySchedule();
+  if (!schedule.enabled) return;
+
+  const alarm = await browser.alarms.get(scheduleAlarmName);
+  if (alarm === undefined || alarm === null) updatePrivacySchedule(false);
 }
 
 // On install
@@ -62,8 +108,14 @@ browser.runtime.onInstalled.addListener(() => {
       var currentKeys = Object.keys(result.settings).sort();
       if(JSON.stringify(defaultKeys) === JSON.stringify(currentKeys)) return;
     }
-    browser.storage.sync.set(defaultSettings);
-  });
+    return browser.storage.sync.set(defaultSettings);
+  }).then(ensurePrivacySchedule).then(() => updatePrivacySchedule(true));
+});
+
+browser.runtime.onStartup.addListener(() => updatePrivacySchedule(true));
+
+browser.alarms.onAlarm.addListener((alarm) => {
+  if (alarm.name === scheduleAlarmName) updatePrivacySchedule(true);
 });
 
 // Handle toggle command
@@ -83,9 +135,15 @@ browser.commands.onCommand.addListener((command) => {
 
 // Update icon on setting change
 browser.storage.onChanged.addListener((changes, area) => {
-  if (area != "sync" || changes.settings == null) return;
+  if (area !== "sync") return;
 
-  browser.action.setIcon({
-    path: "images/status" + (changes.settings.newValue.on == true ? "On" : "Off") + ".png"
-  });
+  if (changes.settings !== undefined) {
+    browser.action.setIcon({
+      path: "images/status" + (changes.settings.newValue.on == true ? "On" : "Off") + ".png"
+    });
+  }
+
+  if (changes[scheduleIdentifier] !== undefined) updatePrivacySchedule(true);
 });
+
+ensurePrivacyScheduleAlarm();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -19,7 +19,7 @@
     "48": "images/icon48.png",
     "128": "images/icon128.png"
   },
-  "permissions": ["storage"],
+  "permissions": ["storage", "alarms"],
   "host_permissions": ["https://web.whatsapp.com/*"],
   "background": {
     "service_worker": "background.js"

--- a/src/manifest_firefox.json
+++ b/src/manifest_firefox.json
@@ -19,10 +19,10 @@
     "48": "images/icon48.png",
     "128": "images/icon128.png"
   },
-  "permissions": ["storage"],
+  "permissions": ["storage", "alarms"],
   "host_permissions": ["https://web.whatsapp.com/*"],
   "background": {
-    "scripts": ["background.js"]
+    "scripts": ["schedule.js", "background.js"]
   },
   "browser_specific_settings": {
     "gecko": {

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -144,6 +144,42 @@
         .main-toggle {
           padding-right: 14px;
         }
+        .schedule-settings {
+          padding-right: 14px;
+        }
+        .schedule-times {
+          display: flex;
+          gap: 10px;
+          margin-top: 8px;
+        }
+        .schedule-time {
+          flex: 1;
+        }
+        .schedule-time locales {
+          display: block;
+          font-size: smaller;
+          margin-bottom: 4px;
+        }
+        .schedule-time input {
+          box-sizing: border-box;
+          width: 100%;
+          padding: 4px;
+          color: var(--text-color);
+          background-color: var(--bg-color);
+          border: 1px solid var(--border-color-blur-input);
+          border-radius: 3px;
+          outline: 2px solid transparent;
+        }
+        .schedule-time input:focus-visible {
+          border-color: var(--primary-color);
+          outline-color: color-mix(in srgb, var(--primary-color), var(--bg-color) 50%);
+        }
+        .schedule-help {
+          margin-top: 8px;
+          color: var(--text-color-unit);
+          font-size: smaller;
+          line-height: 1.4;
+        }
         .on-off-toggle {
           display: flex;
           align-items: center;
@@ -588,6 +624,32 @@
           </div>
           <br>
         </div>
+        <div class="schedule-settings">
+          <hr>
+          <div class="on-off-toggle">
+            <h2>
+              <locales data-locale="privacySchedule"></locales>
+            </h2>
+            <input type="checkbox" id="privacySchedule" data-style="privacySchedule">
+            <label for="privacySchedule" data-localetitle="privacyScheduleDescription">
+              <locales data-locale="privacySchedule"></locales>
+            </label>
+          </div>
+          <div class="schedule-times">
+            <div class="schedule-time">
+              <locales id="scheduleStartLabel" data-locale="scheduleStart"></locales>
+              <input type="time" id="scheduleStart" aria-labelledby="scheduleStartLabel">
+            </div>
+            <div class="schedule-time">
+              <locales id="scheduleEndLabel" data-locale="scheduleEnd"></locales>
+              <input type="time" id="scheduleEnd" aria-labelledby="scheduleEndLabel">
+            </div>
+          </div>
+          <p class="schedule-help">
+            <locales data-locale="scheduleHelp"></locales>
+          </p>
+          <br>
+        </div>
         <h2 style="margin: 5px 0; padding-right: 14px;">
           <locales data-locale="extensionSettings"></locales>
         </h2>
@@ -873,6 +935,7 @@
       
       <div id="toast-container"></div>
 
+      <script src="../schedule.js"></script>
       <script src="popup.js"></script>
       <script src="theme-toggle.js"></script>
     </body>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -11,6 +11,7 @@ if (typeof browser == "undefined") {
 
 const styleIdentifier = "pfwa";
 const settingsIdentifier = "settings";
+const scheduleIdentifier = "privacySchedule";
 
 let version = browser.runtime.getManifest().version;
 document.getElementById('version').innerText = version;
@@ -26,6 +27,11 @@ document.querySelectorAll('[data-localetitle]').forEach(e => {
 function saveSettings() {
   let id = this.dataset.style;
   let checked = this.checked;
+
+  if (id === scheduleIdentifier) {
+    savePrivacySchedule();
+    return;
+  }
 
   browser.storage.sync.get([settingsIdentifier]).then((result) => {
     if (!result.hasOwnProperty(settingsIdentifier)) {
@@ -46,6 +52,49 @@ const switches = document.querySelectorAll("input[type='checkbox']");
 switches.forEach((checkbox) => {
   checkbox.addEventListener('change', saveSettings);
 });
+
+const scheduleToggle = document.getElementById(scheduleIdentifier);
+const scheduleStart = document.getElementById("scheduleStart");
+const scheduleEnd = document.getElementById("scheduleEnd");
+
+function displayPrivacySchedule(schedule) {
+  schedule = { ...globalThis.privacySchedule.defaults, ...schedule };
+  if (!globalThis.privacySchedule.isValid(schedule)) {
+    schedule = { ...globalThis.privacySchedule.defaults };
+  }
+  scheduleToggle.checked = schedule.enabled;
+  scheduleStart.value = schedule.start;
+  scheduleEnd.value = schedule.end;
+}
+
+function savePrivacySchedule() {
+  browser.storage.sync.get([scheduleIdentifier]).then((result) => {
+    let previous = {
+      ...globalThis.privacySchedule.defaults,
+      ...result[scheduleIdentifier]
+    };
+    if (!globalThis.privacySchedule.isValid(previous)) {
+      previous = { ...globalThis.privacySchedule.defaults };
+    }
+
+    const schedule = {
+      enabled: scheduleToggle.checked,
+      start: scheduleStart.value,
+      end: scheduleEnd.value
+    };
+
+    if (!globalThis.privacySchedule.isValid(schedule)) {
+      displayPrivacySchedule(previous);
+      showToast(browser.i18n.getMessage("scheduleInvalid"));
+      return;
+    }
+
+    browser.storage.sync.set({ [scheduleIdentifier]: schedule });
+  });
+}
+
+scheduleStart.addEventListener("change", savePrivacySchedule);
+scheduleEnd.addEventListener("change", savePrivacySchedule);
 
 // toggle open/close blur amount settings
 const onClickOutside = (targetElement, callback, once = true) => {
@@ -188,7 +237,7 @@ forms.forEach((form) => {
 
 
 // Load settings and update switches
-browser.storage.sync.get([settingsIdentifier]).then((result) => {
+browser.storage.sync.get([settingsIdentifier, scheduleIdentifier]).then((result) => {
   if (!result.hasOwnProperty(settingsIdentifier)) {
     browser.runtime.reload();
     return;
@@ -196,7 +245,9 @@ browser.storage.sync.get([settingsIdentifier]).then((result) => {
 
   switches.forEach((checkbox) => {
     let id = checkbox.dataset.style;
-    if (id == "on") {
+    if (id === scheduleIdentifier) {
+      checkbox.checked = result[scheduleIdentifier]?.enabled || false;
+    } else if (id == "on") {
       checkbox.checked = result.settings.on;
     } else if (id === "blurOnIdle") {
       checkbox.checked = result.settings?.blurOnIdle?.isEnabled;
@@ -216,4 +267,17 @@ browser.storage.sync.get([settingsIdentifier]).then((result) => {
     }
   })
 
+  displayPrivacySchedule(result[scheduleIdentifier]);
+});
+
+browser.storage.onChanged.addListener((changes, area) => {
+  if (area !== "sync") return;
+
+  if (changes.settings !== undefined) {
+    document.getElementById("on").checked = changes.settings.newValue.on;
+  }
+
+  if (changes[scheduleIdentifier] !== undefined) {
+    displayPrivacySchedule(changes[scheduleIdentifier].newValue);
+  }
 });

--- a/src/schedule.js
+++ b/src/schedule.js
@@ -1,0 +1,49 @@
+/* Privacy for WhatsApp Web (Auto Blur WA)                           */
+/* Original Copyright (c) 2024 Lukas Lenhardt - lukaslen.com         */
+/* Fork & Maintenance Copyright (c) 2026 M Aryo Muzakki - muzakki.id */
+/* Released under the MIT license, see LICENSE file for details      */
+
+(() => {
+  const defaults = Object.freeze({
+    enabled: false,
+    start: "09:00",
+    end: "17:00",
+  });
+
+  const toMinutes = (value) => {
+    if (!/^([01]\d|2[0-3]):[0-5]\d$/.test(value || "")) return null;
+    const [hours, minutes] = value.split(":").map(Number);
+    return hours * 60 + minutes;
+  };
+
+  const isValid = (schedule) => {
+    const start = toMinutes(schedule?.start);
+    const end = toMinutes(schedule?.end);
+    return start !== null && end !== null && start !== end;
+  };
+
+  const isActive = (schedule, now = new Date()) => {
+    if (!schedule?.enabled || !isValid(schedule)) return false;
+
+    const current = now.getHours() * 60 + now.getMinutes();
+    const start = toMinutes(schedule.start);
+    const end = toMinutes(schedule.end);
+    return start < end
+      ? current >= start && current < end
+      : current >= start || current < end;
+  };
+
+  const getNextChange = (schedule, now = new Date()) => {
+    if (!schedule?.enabled || !isValid(schedule)) return null;
+
+    const [hours, minutes] = (isActive(schedule, now) ? schedule.end : schedule.start)
+      .split(":")
+      .map(Number);
+    const next = new Date(now);
+    next.setHours(hours, minutes, 0, 0);
+    if (next <= now) next.setDate(next.getDate() + 1);
+    return next.getTime();
+  };
+
+  globalThis.privacySchedule = { defaults, isValid, isActive, getNextChange };
+})();


### PR DESCRIPTION
Adds an optional daily schedule that turns privacy on and off at the selected times.

The schedule is disabled by default and uses the browser's local time. It supports overnight ranges, and manual changes stay in place until the next scheduled time.

This updates the popup, background alarms, Chrome and Firefox manifests, translations, and README.

Tested manually with daytime and overnight schedules, manual overrides, equal-time validation, and disabling the schedule.

Closes #11