### PR TITLE
Add Arabic translation and RTL support

### DIFF
--- a/src/_locales/ar/messages.json
+++ b/src/_locales/ar/messages.json
@@ -1,0 +1,176 @@
+{
+    "extensionName": {
+        "message": "الخصوصية لواتساب ويب (تمويه تلقائي)"
+    },
+    "extensionDescription": {
+        "message": "يُموّه تلقائيًا الرسائل والوسائط والأسماء والمزيد في واتساب ويب حتى تمرر مؤشر الفأرة فوقها. نسخة مجتمعية تتم صيانتها باستمرار"
+    },
+    "extensionShortcut": {
+        "message": "تشغيل/إيقاف"
+    },
+    "extensionToggle": {
+        "message": "تشغيل/إيقاف"
+    },
+    "extensionToggleDescription": {
+        "message": "تشغيل الإضافة أو إيقافها"
+    },
+    "extensionSettings": {
+        "message": "الإعدادات"
+    },
+    "privacySchedule": {
+        "message": "جدول الخصوصية"
+    },
+    "privacyScheduleDescription": {
+        "message": "تشغيل الخصوصية وإيقافها تلقائيًا في أوقات محددة."
+    },
+    "scheduleStart": {
+        "message": "البداية"
+    },
+    "scheduleEnd": {
+        "message": "النهاية"
+    },
+    "scheduleHelp": {
+        "message": "يستخدم التوقيت المحلي للمتصفح. تستمر التغييرات اليدوية حتى الموعد المجدول التالي."
+    },
+    "scheduleInvalid": {
+        "message": "يجب أن يختلف وقت البداية عن وقت النهاية."
+    },
+    "toggleMessages": {
+        "message": "جميع الرسائل في المحادثة"
+    },
+    "toggleMessagesDescription": {
+        "message": "يُموّه جميع الرسائل في المحادثة."
+    },
+    "toggleMessagesPreview": {
+        "message": "معاينة آخر الرسائل"
+    },
+    "toggleMessagesPreviewDescription": {
+        "message": "يُموّه جميع معاينات الرسائل في القائمة الجانبية."
+    },
+    "toggleMediaPreview": {
+        "message": "معاينة الوسائط"
+    },
+    "toggleMediaPreviewDescription": {
+        "message": "يُموّه الصور ومقاطع الفيديو والملصقات وغيرها بشكل منفصل عن النص."
+    },
+    "toggleMediaGallery": {
+        "message": "معرض الوسائط"
+    },
+    "toggleMediaGalleryDescription": {
+        "message": "يُموّه أيقونات معاينة الصور ومقاطع الفيديو وغيرها عند عرض أحدها."
+    },
+    "toggleTextInput": {
+        "message": "حقل إدخال النص"
+    },
+    "toggleTextInputDescription": {
+        "message": "يجعل لون النص في حقل الإدخال أفتح ليصعب قراءته."
+    },
+    "toggleProfilePic": {
+        "message": "صور الملف الشخصي"
+    },
+    "toggleProfilePicDescription": {
+        "message": "يُموّه جميع صور الملف الشخصي."
+    },
+    "toggleName": {
+        "message": "أسماء المجموعات والمستخدمين"
+    },
+    "toggleNameDescription": {
+        "message": "يُموّه جميع أسماء المجموعات والمستخدمين."
+    },
+    "toggleNoDelay": {
+        "message": "بدون تأخير للانتقال"
+    },
+    "toggleNoDelayDescription": {
+        "message": "يتيح إلغاء التأخير قبل إظهار العنصر عند تمرير المؤشر فوقه."
+    },
+    "toggleUnblurActive": {
+        "message": "إلغاء التمويه عند تمرير المؤشر فوق التطبيق"
+    },
+    "toggleUnblurActiveDescription": {
+        "message": "يلغي تمويه جميع العناصر عند تمرير المؤشر فوق تطبيق واتساب ويب."
+    },
+    "toggleBlurOnIdle": {
+        "message": "تمويه واتساب عند الخمول"
+    },
+    "toggleBlurOnIdleDescription": {
+        "message": "يُموّه واتساب بعد مدة محددة من عدم استخدام الفأرة أو لوحة المفاتيح."
+    },
+    "toggleTheme": {
+        "message": "التبديل بين المظهر الفاتح أو الداكن أو إعداد النظام"
+    },
+    "openAdvancedSettings": {
+        "message": "فتح الإعدادات المتقدمة"
+    },
+    "cancel": {
+        "message": "إلغاء"
+    },
+    "resetValue": {
+        "message": "إعادة القيمة الافتراضية"
+    },
+    "toastSaved": {
+        "message": "تم الحفظ!"
+    },
+    "blurInputLabel": {
+        "message": "مقدار التمويه"
+    },
+    "msBlurInputDescription": {
+        "message": "تعيين مقدار التمويه لجميع الرسائل (بالبكسل)."
+    },
+    "mspBlurInputDescription": {
+        "message": "تعيين مقدار التمويه لمعاينات الرسائل (بالبكسل)."
+    },
+    "mdpBlurInputDescription": {
+        "message": "تعيين مقدار التمويه لمعاينة الوسائط (بالبكسل)."
+    },
+    "mdgBlurInputDescription": {
+        "message": "تعيين مقدار التمويه لمعرض الوسائط (بالبكسل)."
+    },
+    "ppSmBlurInputLabel": {
+        "message": "مقدار تمويه الصور الصغيرة"
+    },
+    "ppSmBlurInputDescription": {
+        "message": "تعيين مقدار التمويه لصور الملف الشخصي الصغيرة (بالبكسل)."
+    },
+    "ppBlurInputLabel": {
+        "message": "مقدار تمويه الصور بالحجم العادي"
+    },
+    "ppBlurInputDescription": {
+        "message": "تعيين مقدار التمويه لصور الملف الشخصي بالحجم العادي (بالبكسل)."
+    },
+    "ppLgBlurInputLabel": {
+        "message": "مقدار تمويه الصور الكبيرة"
+    },
+    "ppLgBlurInputDescription": {
+        "message": "تعيين مقدار التمويه لصور الملف الشخصي الكبيرة (بالبكسل)."
+    },
+    "nmBlurInputDescription": {
+        "message": "تعيين مقدار التمويه لأسماء المجموعات والمستخدمين (بالبكسل)."
+    },
+    "itBlurInputLabel": {
+        "message": "مهلة الخمول"
+    },
+    "itBlurInputDescription": {
+        "message": "تعيين مدة الخمول (بالثواني)."
+    },
+    "wiBlurInputLabel": {
+        "message": "مقدار التمويه"
+    },
+    "wiBlurInputDescription": {
+        "message": "تعيين مقدار التمويه عند الخمول."
+    },
+    "footerBugReports": {
+        "message": "تقارير الأخطاء والاقتراحات"
+    },
+    "footerBugReportsDescription": {
+        "message": "إذا واجهت مشكلة أو كان لديك اقتراح، فيُرجى فتح بلاغ في مستودع GitHub."
+    },
+    "footerAuthor": {
+        "message": "المطوّر"
+    },
+    "footerReleaseNotes": {
+        "message": "ملاحظات الإصدار"
+    },
+    "footerReleaseNotesDescription": {
+        "message": "عرض ملاحظات الإصدار."
+    }
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -53,7 +53,7 @@
       "suggested_key": {
         "default": "Alt+X"
       },
-      "description": "Toggle On/Off"
+      "description": "__MSG_extensionShortcut__"
     }
   }
 }

--- a/src/manifest_firefox.json
+++ b/src/manifest_firefox.json
@@ -62,7 +62,7 @@
       "suggested_key": {
         "default": "Alt+X"
       },
-      "description": "Toggle On/Off"
+      "description": "__MSG_extensionShortcut__"
     }
   }
 }

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -51,7 +51,8 @@
           color: var(--text-color);
           background-color: var(--bg-color);
           width: 260px;
-          padding: 10px 0 10px 12px;
+          padding: 10px 0;
+          padding-inline-start: 12px;
           -moz-user-select: none;
           user-select: none;
           transition: color .3s, background-color .3s;
@@ -64,7 +65,7 @@
           display: flex;
           align-items: center;
           justify-content: space-between;
-          padding-right: 14px;
+          padding-inline-end: 14px;
         }
         .header-group {
           display: flex;
@@ -72,14 +73,14 @@
           flex: 1;
         }
         .header-group img {
-          margin-left: 5px;
+          margin-inline-start: 5px;
           width: 28px;
           height: 28px;
           flex-shrink: 0;
         }
         h1 {
           font-size: larger;
-          margin-left: 12px;
+          margin-inline-start: 12px;
           display: block;
         }
         .theme-toggle {
@@ -142,7 +143,7 @@
           display: inline-block;
         }
         .main-toggle {
-          padding-right: 14px;
+          padding-inline-end: 14px;
         }
         .on-off-toggle {
           display: flex;
@@ -157,7 +158,7 @@
         }
         #mainContent > .wrapper > ul {
           overflow: auto;
-          padding-right: 14px;
+          padding-inline-end: 14px;
           padding-bottom: 6px;
           /* to set scrollbar only to the settings, currently disable because the main html scroll bug for firefox */
           /* max-height: 415px; */
@@ -217,7 +218,7 @@
           text-decoration: underline;
         }
         #footer {
-          padding-right: 14px;
+          padding-inline-end: 14px;
           clear: both;
         }
         #footer p {
@@ -230,7 +231,7 @@
           line-height: 1.7em;
         }
         #popupMessageButton {
-          float: right;
+          float: inline-end;
           margin: 10px;
         }
         .trigger-btn {
@@ -365,7 +366,7 @@
           border: none;
           background: none;
           padding: 4px 0 10px;
-          margin-left: 32.5%;
+          margin-inline-start: 32.5%;
           margin-bottom: 0;
           width: 35%;
           height: auto;
@@ -436,9 +437,9 @@
           color: var(--text-color);
           background-color: var(--bg-color);
           border: 1px solid var(--border-color-blur-input);
-          border-top-left-radius: 4px;
-          border-bottom-left-radius: 4px;
-          border-right: none;
+          border-start-start-radius: 4px;
+          border-end-start-radius: 4px;
+          border-inline-end: none;
           outline: 1px solid transparent;
           outline-offset: 0px;
         }
@@ -474,8 +475,8 @@
           text-align: center;
           line-height: 23px;
           border: 1px solid var(--border-color-blur-input);
-          border-top-right-radius: 4px;
-          border-bottom-right-radius: 4px;
+          border-start-end-radius: 4px;
+          border-end-end-radius: 4px;
           background-color: var(--bg-color-submit-btn);
           color: var(--text-color);
           transition: .3s;
@@ -495,7 +496,7 @@
         #toast-container {
           position: fixed;
           top: 16px;
-          left: 16px;
+          inset-inline-start: 16px;
           display: flex;
           flex-direction: column;
           gap: 8px;
@@ -531,7 +532,7 @@
           width: 20px;
           height: 20px;
           border-radius: 999px;
-          margin-right: 4px;
+          margin-inline-end: 4px;
           margin-bottom: 0;
           transition: 0.3s;
           cursor: pointer;
@@ -554,7 +555,7 @@
       <header>
         <div class="header-group">
           <img src="../images/icon32.png" alt="">
-          <h1>Privacy for WhatsApp Web (Auto Blur WA)</h1>
+          <h1><locales data-locale="extensionName"></locales></h1>
         </div>
         <button class="theme-toggle" data-localetitle="toggleTheme">
           <!-- tabler:sun -->
@@ -588,7 +589,7 @@
           </div>
           <br>
         </div>
-        <h2 style="margin: 5px 0; padding-right: 14px;">
+        <h2 style="margin: 5px 0; padding-inline-end: 14px;">
           <locales data-locale="extensionSettings"></locales>
         </h2>
         <div class="wrapper">
@@ -867,7 +868,7 @@
       <span id="popupMessage"></span>
       <div id="footer">
         <hr style="margin-top: 2px;">
-        <p><a href="https://github.com/aryomuzakki/privacy-whatsapp-web-auto-blur/issues" data-localetitle="footerBugReportsDescription" target="_blank"><locales data-locale="footerBugReports"></locales></a> - <a href="https://muzakki.id" title="by M Aryo Muzakki" target="_blank"><locales data-locale="footerAuthor"></locales></a>
+        <p><a href="https://github.com/aryomuzakki/privacy-whatsapp-web-auto-blur/issues" data-localetitle="footerBugReportsDescription" target="_blank"><locales data-locale="footerBugReports"></locales></a> - <a href="https://muzakki.id" title="M Aryo Muzakki" target="_blank"><locales data-locale="footerAuthor"></locales></a>
         <br>v<span id="version">0.0.0</span> - <a href="https://github.com/aryomuzakki/privacy-whatsapp-web-auto-blur/releases" data-localetitle="footerReleaseNotesDescription" target="_blank"><locales data-locale="footerReleaseNotes"></locales></a></p>
       </div>
       

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -9,6 +9,9 @@ if (typeof browser == "undefined") {
   globalThis.browser = chrome;
 }
 
+document.documentElement.lang = browser.i18n.getUILanguage();
+document.documentElement.dir = browser.i18n.getMessage("@@bidi_dir");
+
 const styleIdentifier = "pfwa";
 const settingsIdentifier = "settings";
 


### PR DESCRIPTION
Adds a complete Arabic translation for the extension and popup.

The popup now follows the browser's language direction, so Arabic is displayed right-to-left while existing locales stay left-to-right. I also moved the popup heading and keyboard shortcut description into the existing localization flow.

The Arabic locale includes the privacy schedule strings from #13 so they are ready when that change lands.

Tested manually in Chrome in Arabic and English, including advanced settings, tooltips, and both RTL and LTR layouts.